### PR TITLE
[Feat] 코드 비교 조회 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+	// AWS SDK
+	implementation platform('software.amazon.awssdk:bom:2.20.162')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 dependencyManagement {

--- a/src/main/java/Codify/result/config/AwsConfig.java
+++ b/src/main/java/Codify/result/config/AwsConfig.java
@@ -1,0 +1,45 @@
+package Codify.result.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${aws.region:ap-northeast-2}")
+    private String awsRegion;
+
+    @Value("${aws.accessKey:}")
+    private String awsAccessKey;
+
+    @Value("${aws.secretKey:}")
+    private String awsSecretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        if (awsAccessKey.isEmpty() || awsSecretKey.isEmpty()) {
+            // 기본 credential provider chain 사용
+            return S3Client.builder()
+                    .region(Region.of(awsRegion))
+                    .build();
+        } else {
+            AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(awsAccessKey, awsSecretKey);
+            
+            return S3Client.builder()
+                    .region(Region.of(awsRegion))
+                    .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                    .build();
+        }
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/Codify/result/config/SwaggerConfig.java
+++ b/src/main/java/Codify/result/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package Codify.result.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Codify Result API")
+                .description("Codify Result API 명세서")
+                .version("1.0.0");
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info);
+
+    }
+}

--- a/src/main/java/Codify/result/domain/Codeline.java
+++ b/src/main/java/Codify/result/domain/Codeline.java
@@ -1,0 +1,32 @@
+package Codify.result.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "Codeline")
+public class Codeline {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "codelineId")
+    private Long codelineId;
+    
+    @Column(name = "resultId")
+    private Long resultId;
+    
+    @Column(name = "studentId")
+    private Long studentId;
+    
+    @Column(name = "startLine")
+    private Integer startLine;
+    
+    @Column(name = "endLine")
+    private Integer endLine;
+}

--- a/src/main/java/Codify/result/domain/Result.java
+++ b/src/main/java/Codify/result/domain/Result.java
@@ -1,0 +1,41 @@
+package Codify.result.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(
+        name = "Result",
+        uniqueConstraints = @UniqueConstraint(
+        name = "uk_result_assignment_from_to",
+        columnNames = {"assignmentId", "submission_from_id", "submission_to_id"}
+    )
+)
+public class Result {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resultId")
+    private Long id;
+
+    @Column(name = "submission_from_id")
+    private Long submissionFromId;
+
+    @Column(name = "submission_to_id")
+    private Long submissionToId;
+
+    @Column(name = "student_from_id")
+    private Long studentFromId;
+
+    @Column(name = "student_to_id")
+    private Long studentToId;
+
+    @Column(name = "accumulateResult")
+    private double accumulateResult;
+
+    @Column(name = "assignmentId")
+    private Long assignmentId;
+}

--- a/src/main/java/Codify/result/domain/Submission.java
+++ b/src/main/java/Codify/result/domain/Submission.java
@@ -1,0 +1,39 @@
+package Codify.result.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "Submission")
+public class Submission {
+    @Id
+    @Column(name = "submissionId")
+    private Long submissionId;
+    
+    @Column(name = "assignmentId")
+    private Long assignmentId;
+    
+    @Column(name = "fileName")
+    private String fileName;
+    
+    @Column(name = "week")
+    private Integer week;
+    
+    @Column(name = "submissionDate")
+    private LocalDateTime submissionDate;
+    
+    @Column(name = "studentId")
+    private Long studentId;
+    
+    @Column(name = "studentName")
+    private String studentName;
+    
+    @Column(name = "s3Key")
+    private String s3Key;
+}

--- a/src/main/java/Codify/result/domain/Users.java
+++ b/src/main/java/Codify/result/domain/Users.java
@@ -1,0 +1,21 @@
+package Codify.result.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "Users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Users {
+    @Id
+    @Column(name = "userUuid", columnDefinition = "BINARY(16)")
+    private UUID userUuid;
+}

--- a/src/main/java/Codify/result/exception/ComparisonResultNotFoundException.java
+++ b/src/main/java/Codify/result/exception/ComparisonResultNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class ComparisonResultNotFoundException extends BaseException {
+    public ComparisonResultNotFoundException() {
+        super(ErrorCode.COMPARISON_RESULT_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/result/exception/ErrorCode.java
+++ b/src/main/java/Codify/result/exception/ErrorCode.java
@@ -10,7 +10,25 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E3", "서버 에러가 발생했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존재하지 않는 엔티티입니다."),
 
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "A1", "존재하지 않는 아티클입니다.");
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "A1", "존재하지 않는 아티클입니다."),
+
+    // S3 관련 에러
+    S3_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "S1", "S3에서 파일을 찾을 수 없습니다."),
+    S3_FILE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S2", "S3 파일을 읽는 중 오류가 발생했습니다."),
+
+    // 인증 관련 에러
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "U1", "인증되지 않은 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U2", "사용자를 찾을 수 없습니다."),
+
+    // 비교 관련 에러
+    STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ST1", "해당 학생을 찾을 수 없습니다."),
+    COMPARISON_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ST2", "해당 학생들의 비교 결과를 찾을 수 없습니다."),
+    SAME_STUDENT_COMPARISON(HttpStatus.BAD_REQUEST, "ST3", "동일한 학생끼리는 비교할 수 없습니다."),
+    STUDENT_SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "ST4", "해당 과제에 대한 학생의 제출 결과를 찾을 수 없습니다."),
+
+    // 주차 관련 에러
+    INVALID_WEEK_PARAMETER(HttpStatus.BAD_REQUEST, "W1", "유효하지 않은 주차입니다."),
+    WEEK_NOT_FOUND(HttpStatus.NOT_FOUND, "W2", "해당 과제에 대한 주차 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status; //http 상태 코드
     private final String code; //에러 구분 코드

--- a/src/main/java/Codify/result/exception/InvalidWeekParameterException.java
+++ b/src/main/java/Codify/result/exception/InvalidWeekParameterException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class InvalidWeekParameterException extends BaseException {
+    public InvalidWeekParameterException() {
+        super(ErrorCode.INVALID_WEEK_PARAMETER);
+    }
+}

--- a/src/main/java/Codify/result/exception/S3FileNotFoundException.java
+++ b/src/main/java/Codify/result/exception/S3FileNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class S3FileNotFoundException extends BaseException {
+    public S3FileNotFoundException() {
+        super(ErrorCode.S3_FILE_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/result/exception/S3FileReadException.java
+++ b/src/main/java/Codify/result/exception/S3FileReadException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class S3FileReadException extends BaseException {
+    public S3FileReadException() {
+        super(ErrorCode.S3_FILE_READ_ERROR);
+    }
+}

--- a/src/main/java/Codify/result/exception/SameStudentComparisonException.java
+++ b/src/main/java/Codify/result/exception/SameStudentComparisonException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class SameStudentComparisonException extends BaseException {
+    public SameStudentComparisonException() {
+        super(ErrorCode.SAME_STUDENT_COMPARISON);
+    }
+}

--- a/src/main/java/Codify/result/exception/StudentNotFoundException.java
+++ b/src/main/java/Codify/result/exception/StudentNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class StudentNotFoundException extends BaseException {
+    public StudentNotFoundException() {
+        super(ErrorCode.STUDENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/result/exception/StudentSubmissionNotFoundException.java
+++ b/src/main/java/Codify/result/exception/StudentSubmissionNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class StudentSubmissionNotFoundException extends BaseException {
+    public StudentSubmissionNotFoundException() {
+        super(ErrorCode.STUDENT_SUBMISSION_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/result/exception/UnauthenticatedException.java
+++ b/src/main/java/Codify/result/exception/UnauthenticatedException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class UnauthenticatedException extends BaseException {
+    public UnauthenticatedException() {
+        super(ErrorCode.UNAUTHENTICATED);
+    }
+}

--- a/src/main/java/Codify/result/exception/UserNotFoundException.java
+++ b/src/main/java/Codify/result/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/result/exception/WeekNotFoundException.java
+++ b/src/main/java/Codify/result/exception/WeekNotFoundException.java
@@ -1,0 +1,9 @@
+package Codify.result.exception;
+
+import Codify.result.exception.baseException.BaseException;
+
+public class WeekNotFoundException extends BaseException {
+    public WeekNotFoundException() {
+        super(ErrorCode.WEEK_NOT_FOUND);
+    }
+}

--- a/src/main/java/Codify/result/repository/CodelineRepository.java
+++ b/src/main/java/Codify/result/repository/CodelineRepository.java
@@ -1,0 +1,12 @@
+package Codify.result.repository;
+
+import Codify.result.domain.Codeline;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CodelineRepository extends JpaRepository<Codeline, Long> {
+    List<Codeline> findByResultIdAndStudentId(Long resultId, Long studentId);
+}

--- a/src/main/java/Codify/result/repository/ResultRepository.java
+++ b/src/main/java/Codify/result/repository/ResultRepository.java
@@ -1,0 +1,13 @@
+package Codify.result.repository;
+
+import Codify.result.domain.Result;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ResultRepository extends JpaRepository<Result, Long> {
+    Optional<Result> findByStudentFromIdAndStudentToIdAndAssignmentId(
+            Long studentFromId, Long studentToId, Long assignmentId);
+}

--- a/src/main/java/Codify/result/repository/SubmissionRepository.java
+++ b/src/main/java/Codify/result/repository/SubmissionRepository.java
@@ -1,0 +1,15 @@
+package Codify.result.repository;
+
+import Codify.result.domain.Submission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+    Optional<Submission> findBySubmissionId(Long submissionId);
+    
+    // 특정 과제와 주차에 대한 제출 존재 여부 확인
+    boolean existsByAssignmentIdAndWeek(Long assignmentId, Integer week);
+}

--- a/src/main/java/Codify/result/repository/UserRepository.java
+++ b/src/main/java/Codify/result/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package Codify.result.repository;
+
+import Codify.result.domain.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<Users, UUID> {
+}

--- a/src/main/java/Codify/result/service/ResultService.java
+++ b/src/main/java/Codify/result/service/ResultService.java
@@ -1,0 +1,115 @@
+package Codify.result.service;
+
+import Codify.result.domain.Codeline;
+import Codify.result.domain.Result;
+import Codify.result.exception.*;
+import Codify.result.repository.CodelineRepository;
+import Codify.result.repository.ResultRepository;
+import Codify.result.repository.SubmissionRepository;
+import Codify.result.repository.UserRepository;
+import Codify.result.web.dto.CompareResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ResultService {
+
+    private final ResultRepository resultRepository;
+    private final CodelineRepository codelineRepository;
+    private final S3FileService s3FileService;
+    private final SubmissionInfoService submissionInfoService;
+    private final UserRepository userRepository;
+    private final SubmissionRepository submissionRepository;
+
+    @Transactional(readOnly = true)
+    public CompareResponseDto getCompareResult(UUID userUuid, Long assignmentId, Long studentFromId, Long studentToId, Integer week) {
+
+        // 사용자 검증
+        if (userUuid == null) {
+            throw new UnauthenticatedException();
+        }
+        if (!userRepository.existsById(userUuid)) {
+            throw new UserNotFoundException();
+        }
+        
+        // 기본 파라미터 검증
+        if (studentFromId == null || studentFromId <= 0 || studentToId == null || studentToId <= 0) {
+            throw new StudentNotFoundException();
+        }
+        if (week == null || week <= 0) {
+            throw new InvalidWeekParameterException();
+        }
+        
+        // 동일한 학생끼리 비교 방지
+        if (studentFromId.equals(studentToId)) {
+            throw new SameStudentComparisonException();
+        }
+        
+        // 주차 검증 - Submission 테이블에서 해당 과제의 해당 주차가 존재하는지 확인
+        if (!submissionRepository.existsByAssignmentIdAndWeek(assignmentId, week)) {
+            throw new WeekNotFoundException();
+        }
+
+        // Result 테이블에서 결과 조회
+        Result result = resultRepository.findByStudentFromIdAndStudentToIdAndAssignmentId(
+                studentFromId, studentToId, assignmentId
+        ).orElseThrow(() -> new ComparisonResultNotFoundException());
+
+        // 각 학생별 표절된 코드 라인 정보 조회
+        List<Codeline> student1Lines = codelineRepository.findByResultIdAndStudentId(
+                result.getId(), studentFromId
+        );
+        List<Codeline> student2Lines = codelineRepository.findByResultIdAndStudentId(
+                result.getId(), studentToId
+        );
+
+        // 제출 정보 조회
+        SubmissionInfoService.SubmissionInfo submission1 = submissionInfoService.getSubmissionInfo(result.getSubmissionFromId());
+        SubmissionInfoService.SubmissionInfo submission2 = submissionInfoService.getSubmissionInfo(result.getSubmissionToId());
+
+        // 표절 라인 변환
+        List<Integer> lines1 = convertToLineNumbers(student1Lines);
+        List<Integer> lines2 = convertToLineNumbers(student2Lines);
+
+        // S3에서 표절된 라인의 코드만 조회
+        List<String> code1 = s3FileService.getSpecificLinesFromS3(submission1.getS3Key(), lines1);
+        List<String> code2 = s3FileService.getSpecificLinesFromS3(submission2.getS3Key(), lines2);
+
+        return CompareResponseDto.builder()
+                .student1(CompareResponseDto.StudentCompareDto.builder()
+                        .id(studentFromId.toString())
+                        .name(submission1.getStudentName())
+                        .fileName(submission1.getFileName())
+                        .submissionTime(submission1.getSubmissionTime())
+                        .code(code1)
+                        .lines(lines1)
+                        .build())
+                .student2(CompareResponseDto.StudentCompareDto.builder()
+                        .id(studentToId.toString())
+                        .name(submission2.getStudentName())
+                        .fileName(submission2.getFileName())
+                        .submissionTime(submission2.getSubmissionTime())
+                        .code(code2)
+                        .lines(lines2)
+                        .build())
+                .build();
+    }
+
+    private List<Integer> convertToLineNumbers(List<Codeline> codelines) {
+        return codelines.stream()
+                .flatMapToInt(codeline ->
+                        IntStream.rangeClosed(codeline.getStartLine(), codeline.getEndLine()))
+                .distinct() // 중복 라인 번호 제거
+                .sorted() // 오름차순 정렬
+                .boxed()
+                .toList();
+    }
+}

--- a/src/main/java/Codify/result/service/S3FileService.java
+++ b/src/main/java/Codify/result/service/S3FileService.java
@@ -1,0 +1,72 @@
+package Codify.result.service;
+
+import Codify.result.exception.S3FileNotFoundException;
+import Codify.result.exception.S3FileReadException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3FileService {
+
+    private final S3Client s3Client;
+    
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    public List<String> getCodeFromS3(String s3Key) {
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName) // S3 버킷명
+                    .key(s3Key)         // 파일 경로/이름
+                    .build();
+
+            List<String> codeLines = new ArrayList<>();
+            
+            // 파일 읽기
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(
+                            s3Client.getObject(getObjectRequest), // S3에서 파일을 InputStream으로 가져옴
+                            StandardCharsets.UTF_8
+                    ))) {
+                
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    codeLines.add(line);
+                }
+            }
+            
+            return codeLines;
+            
+        } catch (NoSuchKeyException e) {
+            log.error("File not found in S3: {}", s3Key);
+            throw new S3FileNotFoundException();
+        } catch (IOException e) {
+            log.error("Failed to read file from S3: {}", s3Key, e);
+            throw new S3FileReadException();
+        }
+    }
+    
+    // 특정 라인 번호들에 해당하는 코드만 가져오기
+    public List<String> getSpecificLinesFromS3(String s3Key, List<Integer> lineNumbers) {
+        List<String> allLines = getCodeFromS3(s3Key);
+        
+        return lineNumbers.stream()
+                .filter(lineNum -> lineNum > 0 && lineNum <= allLines.size())
+                .map(lineNum -> allLines.get(lineNum - 1)) // 1-based -> 0-based 인덱스 변환
+                .toList();
+    }
+}

--- a/src/main/java/Codify/result/service/SubmissionInfoService.java
+++ b/src/main/java/Codify/result/service/SubmissionInfoService.java
@@ -1,0 +1,76 @@
+package Codify.result.service;
+
+import Codify.result.domain.Submission;
+import Codify.result.exception.StudentSubmissionNotFoundException;
+import Codify.result.repository.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubmissionInfoService {
+
+    private final SubmissionRepository submissionRepository;
+
+    @Value("${codify.timezone.source:UTC}")
+    private String sourceTimezone;
+
+    @Value("${codify.timezone.target:Asia/Seoul}")
+    private String targetTimezone;
+
+    @Value("${codify.timezone.format:yyyy-MM-dd HH:mm}")
+    private String dateFormat;
+
+    @Transactional(readOnly = true)
+    public SubmissionInfo getSubmissionInfo(Long submissionId) {
+        // 제출 정보 조회
+        Submission submission = submissionRepository.findBySubmissionId(submissionId)
+                .orElseThrow(() -> new StudentSubmissionNotFoundException());
+        
+        // UTC → KST 변환
+        ZonedDateTime targetTime = submission.getSubmissionDate()
+                .atZone(ZoneId.of(sourceTimezone))
+                .withZoneSameInstant(ZoneId.of(targetTimezone));
+
+        String formattedTime = targetTime.format(DateTimeFormatter.ofPattern(dateFormat));
+        
+        // 어떤 제출물을 조회했는지 추적, 문제 발생 시 호출 이력 확인
+        log.info("Retrieved submission info for submissionId: {}, fileName: {}",
+                submissionId, submission.getFileName());
+        
+        return new SubmissionInfo(
+                submission.getFileName(), 
+                submission.getStudentName(), 
+                formattedTime,
+                submission.getS3Key()
+        );
+    }
+
+    // 제출 정보를 나타내는 클래스
+    public static class SubmissionInfo {
+        private final String fileName;
+        private final String studentName;
+        private final String submissionTime;
+        private final String s3Key;
+
+        public SubmissionInfo(String fileName, String studentName, String submissionTime, String s3Key) {
+            this.fileName = fileName;
+            this.studentName = studentName;
+            this.submissionTime = submissionTime;
+            this.s3Key = s3Key;
+        }
+
+        public String getFileName() { return fileName; }
+        public String getStudentName() { return studentName; }
+        public String getSubmissionTime() { return submissionTime; }
+        public String getS3Key() { return s3Key; }
+    }
+}

--- a/src/main/java/Codify/result/web/controller/ResultController.java
+++ b/src/main/java/Codify/result/web/controller/ResultController.java
@@ -1,0 +1,45 @@
+package Codify.result.web.controller;
+
+import Codify.result.service.ResultService;
+import Codify.result.web.dto.CompareResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/result")
+@Slf4j
+public class ResultController {
+
+    private final ResultService resultService;
+
+    @Operation(
+            operationId = "compareStudentSubmissions",
+            summary = "두 학생의 제출물 비교 결과 조회",
+            description = """
+            두 학생의 제출물을 비교한 결과를 반환합니다.
+            - studentFromId, studentToId: 비교할 학생 ID
+            - week: 주차 정보
+            - S3에서 실제 코드 파일과 함께 표절 의심라인 반환
+            """
+    )
+    @GetMapping("/assignments/{assignmentId}/compare")
+    public ResponseEntity<CompareResponseDto> compareStudents(
+            @RequestHeader("USER-UUID") String userUuidHeader,
+            @PathVariable Long assignmentId,
+            @RequestParam("studentFromId") Long studentFromId,
+            @RequestParam("studentToId") Long studentToId,
+            @RequestParam("week") Integer week
+    ) {
+        final UUID userUuid = UUID.fromString(userUuidHeader);
+        
+        CompareResponseDto compareResult = resultService.getCompareResult(userUuid, assignmentId, studentFromId, studentToId, week);
+        return ResponseEntity.ok(compareResult);
+    }
+}

--- a/src/main/java/Codify/result/web/dto/CompareResponseDto.java
+++ b/src/main/java/Codify/result/web/dto/CompareResponseDto.java
@@ -1,0 +1,21 @@
+package Codify.result.web.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CompareResponseDto(
+        StudentCompareDto student1,
+        StudentCompareDto student2
+) {
+    @Builder
+    public static record StudentCompareDto(
+            String id,
+            String name,
+            String fileName,
+            String submissionTime,
+            List<String> code,
+            List<Integer> lines
+    ) {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_SCHEMA}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  data:
+    mongodb:
+      uri: mongodb+srv://${MONGO_USERNAME}:${MONGO_PASSWORD}@codify.mongocluster.cosmos.azure.com/codify?tls=true&authSource=admin&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000
 
   jpa:
     database: mysql
@@ -29,3 +32,19 @@ eureka:
 
   instance:
     prefer-ip-address: true
+
+# AWS 설정
+aws:
+  region: ap-northeast-2
+  s3:
+    bucket: ${AWS_S3_BUCKET:your-bucket-name}
+  accessKey: ${AWS_ACCESS_KEY:}
+  secretKey: ${AWS_SECRET_KEY:}
+
+codify:
+  dev:
+    user-uuid: ${USER-UUID}
+  timezone:
+    source: UTC
+    target: Asia/Seoul
+    format: "yyyy-MM-dd HH:mm"


### PR DESCRIPTION
### 📝 요약(Summary)
- 두 학생의 코드 표절 비교 결과를 조회하는 API 구현
- 실제 DB와 S3에서 데이터를 가져와서 표절된 부분만 보여주는 기능 완성

### 🛠️ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✨ 주요 변경사항
- **API 엔드포인트**
  - GET /api/result/assignments/{assignmentId}/compare: 과제 ID를 path variable로 URL에 포함했습니다.
  - 두 학생 ID, 주차를 파라미터로 받아서 표절 비교 결과를 반환합니다.
- **DB 사용**
  - MySQL에서 실제 제출 정보(파일명, 학생명, 제출시간) 가져옵니다.
- **S3 파일 처리**
  - 표절된 라인만 선별해서 가져오도록 구현했습니다.
- **에러 처리**
  - 잘못된 학생 ID, 주차, 과제 등에 대한 custom exception 처리 했습니다.

### 💬 공유 사항
- Submit 프로젝트와 동일한 인증 방식을 사용해서 일관성을 맞췄습니다.
- 불필요한 DB 조회를 줄여서 성능을 개선했습니다.
- 환경변수 변동사항 있습니다. 테스트 시 노션 페이지 참고해서 환경변수 변경하신 후에 테스트 부탁드립니다.