### PR TITLE
[Feat] 표절 판단 페이지 구현

### DIFF
--- a/src/main/java/Codify/result/web/controller/ResultController.java
+++ b/src/main/java/Codify/result/web/controller/ResultController.java
@@ -2,6 +2,7 @@ package Codify.result.web.controller;
 
 import Codify.result.service.ResultService;
 import Codify.result.web.dto.CompareResponseDto;
+import Codify.result.web.dto.PlagiarismJudgeResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +42,29 @@ public class ResultController {
         
         CompareResponseDto compareResult = resultService.getCompareResult(userUuid, assignmentId, studentFromId, studentToId, week);
         return ResponseEntity.ok(compareResult);
+    }
+
+    @Operation(
+            operationId = "judgePlagiarism",
+            summary = "표절 판단 결과 조회",
+            description = """
+            두 학생의 제출물에 대한 표절 판단 결과를 반환합니다.
+            - studentFromId, studentToId: 비교할 학생 ID
+            - week: 주차 정보
+            - assignmentId: 과제 ID
+            """
+    )
+    @GetMapping("/assignments/{assignmentId}/judge")
+    public ResponseEntity<PlagiarismJudgeResponseDto> judgePlagiarism(
+            @RequestHeader("USER-UUID") String userUuidHeader,
+            @PathVariable Long assignmentId,
+            @RequestParam("studentFromId") Long studentFromId,
+            @RequestParam("studentToId") Long studentToId,
+            @RequestParam("week") Integer week
+    ) {
+        final UUID userUuid = UUID.fromString(userUuidHeader);
+        
+        PlagiarismJudgeResponseDto judgeResult = resultService.getPlagiarismJudgeResult(userUuid, assignmentId, studentFromId, studentToId, week);
+        return ResponseEntity.ok(judgeResult);
     }
 }

--- a/src/main/java/Codify/result/web/dto/PlagiarismJudgeResponseDto.java
+++ b/src/main/java/Codify/result/web/dto/PlagiarismJudgeResponseDto.java
@@ -1,0 +1,17 @@
+package Codify.result.web.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlagiarismJudgeResponseDto(
+        Integer similarity,
+        StudentInfoDto student1,
+        StudentInfoDto student2
+) {
+    @Builder
+    public static record StudentInfoDto(
+            String id,
+            String name,
+            String submittedTime
+    ) {}
+}


### PR DESCRIPTION
### 📝 요약(Summary)
- 두 학생의 코드 표절 판단 결과를 조회하는 API 구현
- 유사도 퍼센트와 학생 기본 정보만 간단하게 반환

### 🛠️ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✨ 주요 변경사항
- **새로운 API 엔드포인트**
  - GET /api/result/assignments/{assignmentId}/judge: 표절 판단 전용 API 추가

### 💬 공유 사항
